### PR TITLE
TTB-8377- Configurar extensión Cron

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,0 +1,1 @@
+RUN_CRON=true

--- a/package.json
+++ b/package.json
@@ -51,10 +51,12 @@
   "dependencies": {
     "@loopback/boot": "^3.2.1",
     "@loopback/core": "^2.14.1",
+    "@loopback/cron": "^0.4.0",
     "@loopback/repository": "^3.4.1",
     "@loopback/rest": "^9.1.3",
     "@loopback/rest-explorer": "^3.1.0",
     "@loopback/service-proxy": "^3.0.7",
+    "dotenv": "^8.2.0",
     "loopback-connector-rest": "^4.0.1",
     "tslib": "^2.0.0"
   },

--- a/src/application.ts
+++ b/src/application.ts
@@ -9,6 +9,10 @@ import {RestApplication} from '@loopback/rest';
 import {ServiceMixin} from '@loopback/service-proxy';
 import path from 'path';
 import {MySequence} from './sequence';
+import {CronUpdateHolidays} from './components/cron.component';
+
+require('dotenv').config();
+
 
 export {ApplicationConfig};
 
@@ -17,6 +21,10 @@ export class LemonholidaysApplication extends BootMixin(
 ) {
   constructor(options: ApplicationConfig = {}) {
     super(options);
+    //cron component
+    if(process.env.RUN_CRON === 'true'){
+      this.component(CronUpdateHolidays);
+    }
 
     // Set up the custom sequence
     this.sequence(MySequence);

--- a/src/components/cron.component.ts
+++ b/src/components/cron.component.ts
@@ -1,0 +1,19 @@
+import {CronJob, cronJob} from '@loopback/cron';
+
+@cronJob()
+export class CronUpdateHolidays extends CronJob {
+  constructor() {
+    super({
+      name: 'update-holidays',
+      onTick: () => {
+        this.updateHoliday();
+      },
+      cronTime: '*/10 * * * * *', // Cada 10 segundos
+      start: true,
+    });
+  }
+  updateHoliday() {
+    const date : Date = new Date();
+    console.log('Update Holiday is running 🥳. '+ date);
+  }
+}


### PR DESCRIPTION
Ticket TTB-8377
Configurar extensión Cron
Permitir programar tareas


QA
- Descargar rama.
- Instalar dependencias:
`npm install`
- crear archivo .env
- Comprobar que en la consola imprima el mensaje cuando en el archivo .env se configure como `RUN_CRON=true` y que  no se imprima cuando este en `RUN_CRON=false` 