### PR TITLE
TTB-8315 Endpoint de modifiación de feriados

### DIFF
--- a/src/controllers/admin-holiday.controller.ts
+++ b/src/controllers/admin-holiday.controller.ts
@@ -1,0 +1,40 @@
+import {
+  repository
+} from '@loopback/repository';
+import {
+  getModelSchemaRef, param,
+  patch,
+  requestBody,
+  response
+} from '@loopback/rest';
+import {Holidays} from '../models';
+import {HolidaysRepository} from '../repositories';
+
+
+export class AdminHolidayController {
+  constructor(
+    @repository(HolidaysRepository)
+    public holidaysRepository : HolidaysRepository,
+  ) {}
+
+  @patch('/admin/holidays/{id}')
+  @response(204, {
+    description: 'Admin Holiday PATCH success',
+  })
+  async updateById(
+    @param.path.string('id') id: string,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Holidays, {partial: true,exclude:['type','country','createdAt','id','updatedAt','origin']}),
+        },
+      },
+    })
+    holidays: Holidays,
+  ): Promise<void> {
+    holidays.origin = 'manual';
+    holidays.updatedAt = new Date().toString();
+    await this.holidaysRepository.updateById(id, holidays);
+  }
+
+}

--- a/src/controllers/admin-holiday.controller.ts
+++ b/src/controllers/admin-holiday.controller.ts
@@ -33,7 +33,7 @@ export class AdminHolidayController {
     holidays: Holidays,
   ): Promise<void> {
     holidays.origin = 'manual';
-    holidays.updatedAt = new Date().toString();
+    holidays.updatedAt = new Date();
     await this.holidaysRepository.updateById(id, holidays);
   }
 

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -2,3 +2,4 @@ export * from './ping.controller';
 export * from './conuntry.controller';
 export * from './apichile.controller';
 export * from './google.controller';
+export * from './admin-holiday.controller';

--- a/src/models/holidays.model.ts
+++ b/src/models/holidays.model.ts
@@ -19,7 +19,7 @@ export class Holidays extends Entity {
     type: 'date',
     required: true,
   })
-  date: string;
+  date: Date;
 
   @property({
     type: 'string',
@@ -28,10 +28,7 @@ export class Holidays extends Entity {
   type: string;
 
   @property({
-    type: 'string',
-    jsonSchema: {
-      pattern: '^(api|manual)$',
-    },
+    type: 'string'
   })
   origin?: string;
   
@@ -50,12 +47,12 @@ export class Holidays extends Entity {
   @property({
     type: 'date',
   })
-  createdAt?: string;
+  createdAt?: Date;
 
   @property({
     type: 'date',
   })
-  updatedAt?: string;
+  updatedAt?: Date;
 
   constructor(data?: Partial<Holidays>) {
     super(data);

--- a/src/models/holidays.model.ts
+++ b/src/models/holidays.model.ts
@@ -3,11 +3,11 @@ import {Entity, model, property} from '@loopback/repository';
 @model()
 export class Holidays extends Entity {
   @property({
-    type: 'number',
+    type: 'string',
     id: true,
     generated: true,
   })
-  id?: number;
+  id?: string;
 
   @property({
     type: 'string',
@@ -29,6 +29,9 @@ export class Holidays extends Entity {
 
   @property({
     type: 'string',
+    jsonSchema: {
+      pattern: '^(api|manual)$',
+    },
   })
   origin?: string;
   


### PR DESCRIPTION
Ticket TTB-8377
Crear endpoint para modificar feriado…
Se debe permitir modificar una fecha:
Habilitar
Deshabilitar
Mover
Cambiar descripción

QA

Descargar rama.
colocar  datos en el .env de la base de datos Mongo.
enviar request para cambiar datos del feriado ejemplo:
```
curl --location --request PATCH 'http://127.0.0.1:3000/admin/holidays/606f7e62276b2bdcacf43124' \
--header 'Content-Type: application/json' \
--data-raw '{
    "name": "Vienes Santo",
    "active":true,
    "date":"2021-04-02T03:00:00.000Z"
}'
```

