### PR TITLE
TTB-8313 - Crear extracción de datos programada

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-GOOGLE_API_KEY=eiufiwefhiehf
+API_KEY_GOOGLE=eiufiwefhiehf
 
 MONGO_HOST=mongodb+srv://host.to.mongo
 MONGO_DB=database

--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ MONGO_URL=mongodb+srv://user:password@mongodbhost.com/database
 MONGO_PORT=27017
 
 RUN_CRON=true
+CRON_SCHEDULE="0 25 13 */16 * *"

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-API_KEY_GOOGLE=eiufiwefhiehf
+GOOGLE_API_KEY=eiufiwefhiehf
 
 MONGO_HOST=mongodb+srv://host.to.mongo
 MONGO_DB=database

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "googleapis": "^68.0.0",
     "loopback-connector-mongodb": "^5.5.0",
     "loopback-connector-rest": "^4.0.1",
+    "node-cron": "^3.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/src/application.ts
+++ b/src/application.ts
@@ -1,30 +1,25 @@
-import {BootMixin} from '@loopback/boot';
-import {ApplicationConfig} from '@loopback/core';
+import { BootMixin } from '@loopback/boot';
+import { ApplicationConfig } from '@loopback/core';
 import {
   RestExplorerBindings,
   RestExplorerComponent,
 } from '@loopback/rest-explorer';
-import {RepositoryMixin} from '@loopback/repository';
-import {RestApplication} from '@loopback/rest';
-import {ServiceMixin} from '@loopback/service-proxy';
+import { RepositoryMixin } from '@loopback/repository';
+import { RestApplication } from '@loopback/rest';
+import { ServiceMixin } from '@loopback/service-proxy';
 import path from 'path';
-import {MySequence} from './sequence';
-import {CronUpdateHolidays} from './components/cron.component';
+import { MySequence } from './sequence';
 
 require('dotenv').config();
 
 
-export {ApplicationConfig};
+export { ApplicationConfig };
 
 export class LemonholidaysApplication extends BootMixin(
   ServiceMixin(RepositoryMixin(RestApplication)),
 ) {
   constructor(options: ApplicationConfig = {}) {
     super(options);
-    //cron component
-    if(process.env.RUN_CRON === 'true'){
-      this.component(CronUpdateHolidays);
-    }
 
     // Set up the custom sequence
     this.sequence(MySequence);

--- a/src/components/cron.component.ts
+++ b/src/components/cron.component.ts
@@ -1,19 +1,20 @@
-import {CronJob, cronJob} from '@loopback/cron';
+import { repository } from '@loopback/repository';
+import { HolidaysRepository } from '../repositories';
+const cron = require('node-cron');
 
-@cronJob()
-export class CronUpdateHolidays extends CronJob {
-  constructor() {
-    super({
-      name: 'update-holidays',
-      onTick: () => {
-        this.updateHoliday();
-      },
-      cronTime: '*/10 * * * * *', // Cada 10 segundos
-      start: true,
+export class CronComponent {
+  constructor(
+    @repository(HolidaysRepository)
+    public holidaysRepository: HolidaysRepository,
+  ) {
+  }
+
+  async start() {
+    cron.schedule('0 20 3 */16 * *', async () => {
+      const date: Date = new Date();
+      console.log('Update Holiday is running 🥳. ' + date);
+      await this.holidaysRepository.createOrUpdate();
     });
   }
-  updateHoliday() {
-    const date : Date = new Date();
-    console.log('Update Holiday is running 🥳. '+ date);
-  }
+
 }

--- a/src/components/cron.component.ts
+++ b/src/components/cron.component.ts
@@ -10,7 +10,7 @@ export class CronComponent {
   }
 
   async start() {
-    cron.schedule('0 20 3 */16 * *', async () => {
+    cron.schedule(process.env.CRON_SCHEDULE, async () => {
       const date: Date = new Date();
       console.log('Update Holiday is running 🥳. ' + date);
       await this.holidaysRepository.createOrUpdate();

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from './cron.component';

--- a/src/controllers/admin-holiday.controller.ts
+++ b/src/controllers/admin-holiday.controller.ts
@@ -8,8 +8,8 @@ import {
   requestBody,
   response
 } from '@loopback/rest';
-import {Holidays} from '../models';
-import {HolidaysRepository} from '../repositories';
+import { Holidays } from '../models';
+import { HolidaysRepository } from '../repositories';
 
 @api({
   basePath: '/admin/holidays',
@@ -20,7 +20,7 @@ import {HolidaysRepository} from '../repositories';
         'x-operation-name': 'updateById',
         'x-controller-name': 'AdminHolidayController',
         parameters: [
-          {name: 'id', schema: {type: 'string'}},
+          { name: 'id', schema: { type: 'string' } },
         ],
       },
     },
@@ -29,8 +29,8 @@ import {HolidaysRepository} from '../repositories';
 export class AdminHolidayController {
   constructor(
     @repository(HolidaysRepository)
-    public holidaysRepository : HolidaysRepository,
-  ) {}
+    public holidaysRepository: HolidaysRepository,
+  ) { }
 
   @patch('/{id}')
   @response(204, {
@@ -41,13 +41,13 @@ export class AdminHolidayController {
     @requestBody({
       content: {
         'application/json': {
-          schema: getModelSchemaRef(Holidays, {partial: true, exclude:['type', 'country', 'createdAt', 'id', 'updatedAt', 'origin']}),
+          schema: getModelSchemaRef(Holidays, { partial: true, exclude: ['type', 'country', 'createdAt', 'id', 'updatedAt', 'origin'] }),
         },
       },
     })
     holidays: Holidays,
   ): Promise<void> {
-    holidays.origin = 'manual';
+    holidays.origin = 'Manual';
     holidays.updatedAt = new Date();
     await this.holidaysRepository.updateById(id, holidays);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
-import {ApplicationConfig, LemonholidaysApplication} from './application';
+import { ApplicationConfig, LemonholidaysApplication } from './application';
 import dotenv from 'dotenv';
+import { CronComponent } from './components';
+// import { HolidaysController } from './controllers';
+import { HolidaysRepository } from './repositories';
 
 dotenv.config();
 
@@ -13,6 +16,13 @@ export async function main(options: ApplicationConfig = {}) {
   const url = app.restServer.url;
   console.log(`Server is running at ${url}`);
   console.log(`Try ${url}/ping`);
+
+  const holidaysRepository = app.repository(HolidaysRepository);
+  const holidaysRepositoryInstance = await holidaysRepository.getValue(app);
+  const cron = new CronComponent(holidaysRepositoryInstance);
+  if (process.env.RUN_CRON === 'true') {
+    await cron.start();
+  }
 
   return app;
 }

--- a/src/repositories/holidays.repository.ts
+++ b/src/repositories/holidays.repository.ts
@@ -57,9 +57,10 @@ export class HolidaysRepository extends DefaultCrudRepository<
       const countItem = await this.find({ where: { country: country.code } });
       if (countItem.length === 0) {
         await this.createAllByCountry(new Date().getFullYear(), country.code, country.origin);
-      } else {
-        await this.updateAllByCountry(country.code, country.origin);
+        continue;
       }
+
+      await this.updateAllByCountry(country.code, country.origin);
     }
     return null;
   }
@@ -110,17 +111,18 @@ export class HolidaysRepository extends DefaultCrudRepository<
           if (holiday.date >= currentDay) {
             await this.create(holiday);
           }
-        } else {
-
-          //si existe en la base de datos, el feriado se desactiva si el origen es distinto a Manual y mayor o igual a la fecha actual
-          //ademas se crea un nuevo feriado
-          if (holidayFind.origin !== 'Manual' && holidayFind.date >= currentDay) {
-            holidayFind.active = false;
-            holidayFind.updatedAt = new Date();
-            await this.updateById(holidayFind.id, holidayFind);
-            await this.create(holiday);
-          }
+          continue;
         }
+
+        //si existe en la base de datos, el feriado se desactiva si el origen es distinto a Manual y mayor o igual a la fecha actual
+        //ademas se crea un nuevo feriado
+        if (holidayFind.origin !== 'Manual' && holidayFind.date >= currentDay) {
+          holidayFind.active = false;
+          holidayFind.updatedAt = new Date();
+          await this.updateById(holidayFind.id, holidayFind);
+          await this.create(holiday);
+        }
+
       }
     }
 

--- a/src/repositories/holidays.repository.ts
+++ b/src/repositories/holidays.repository.ts
@@ -1,7 +1,11 @@
-import {inject} from '@loopback/core';
-import {DefaultCrudRepository} from '@loopback/repository';
-import {MongoHolidaysDataSource} from '../datasources';
-import {Holidays, HolidaysRelations} from '../models';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { inject } from '@loopback/core';
+import { DefaultCrudRepository } from '@loopback/repository';
+import { MongoHolidaysDataSource } from '../datasources';
+import { Holidays, HolidaysRelations } from '../models';
+import { ApichileService, GoogleCalProvider } from '../services';
+import { ApiChileTranformerService, GoogleApiTransformerService } from '../services';
+import { CountriesRepository } from '../repositories';
 
 export class HolidaysRepository extends DefaultCrudRepository<
   Holidays,
@@ -9,7 +13,18 @@ export class HolidaysRepository extends DefaultCrudRepository<
   HolidaysRelations
 > {
   constructor(
-    @inject('datasources.mongoHolidays') dataSource: MongoHolidaysDataSource,
+    @inject('datasources.mongoHolidays')
+    dataSource: MongoHolidaysDataSource,
+    @inject('services.ApichileService')
+    protected apichileService: ApichileService,
+    @inject('services.ApiChileTranformerService')
+    protected apiChileTranformerService: ApiChileTranformerService,
+    @inject('services.GoogleCalProvider')
+    private googleCal: GoogleCalProvider,
+    @inject('services.GoogleApiTransformerService')
+    private googleApiTransformerService: GoogleApiTransformerService,
+    @inject('repositories.CountriesRepository')
+    private countriesRepository: CountriesRepository
   ) {
     super(Holidays, dataSource);
   }
@@ -28,11 +43,108 @@ export class HolidaysRepository extends DefaultCrudRepository<
             country: country
           },
           {
-            date: {between: [first, last]}
+            date: { between: [first, last] }
           }
         ]
       }
     })
     return result;
   }
+
+  async createOrUpdate() {
+    const countries = await this.countriesRepository.find();
+    for (const country of countries) {
+      const countItem = await this.find({ where: { country: country.code } });
+      if (countItem.length === 0) {
+        await this.createAllByCountry(new Date().getFullYear(), country.code, country.origin);
+      } else {
+        await this.updateAllByCountry(country.code, country.origin);
+      }
+    }
+    return null;
+  }
+
+  async createAllByCountry(year: number, country: string, typeApi: string): Promise<any> {
+    const holidaysApi: any = await this.getHolidayApis(year, country, typeApi);
+    await this.createAll(holidaysApi);
+  }
+
+  async getHolidayApis(year: number, country: string, typeApi: string): Promise<Array<Holidays>> {
+    let holidaysApi: Array<Holidays> = [];
+    if (typeApi === 'Google') {
+      const eventList = await this.googleCal.holidayEvents(year, country);
+      holidaysApi = await this.googleApiTransformerService.transformer(eventList.data, country);
+    } else if (typeApi === 'APIChile') {
+      const data = await this.apichileService.HolidaysByYear(year);
+      holidaysApi = await this.apiChileTranformerService.transformer(data);
+    }
+    return holidaysApi;
+  }
+
+  async updateAllByCountry(country: string, typeApi: string): Promise<any> {
+    const year = new Date().getFullYear();
+    const first = new Date(`${year}-01-01T00:00:00Z`);
+    const last = new Date(`${year}-12-31T23:59:59Z`);
+
+    const holidays = await this.find({
+      order: ["date ASC"],
+      where: { and: [{ country: country }, { date: { between: [first, last] } }], }
+    })
+    const holidaysApi: Holidays[] = await this.getHolidayApis(year, country, typeApi)
+
+    //busco si hay feriados en la api que no  existan en base de datos
+    const missingHolidayApi = holidaysApi.filter(this.diff(holidays));
+    if (missingHolidayApi.length > 0) {
+      for (const holiday of missingHolidayApi) {
+        const holidayFind = await this.findOne({
+          where: {
+            date: holiday.date,
+            country: holiday.country,
+            active: true
+          }
+        });
+
+        //si el feriado no se encuentra en la base de datos se crea
+        if (holidayFind === null) {
+          await this.create(holiday);
+        } else {
+
+          //si existe en la base de datos, se desactiva si el origen es distinto a Manual
+          //y se crea el nuevo feriado
+          if (holidayFind.origin !== 'Manual') {
+            holidayFind.active = false;
+            holidayFind.updatedAt = new Date();
+            await this.updateById(holidayFind.id, holidayFind);
+            await this.create(holiday);
+          }
+        }
+      }
+    }
+
+    //Busco si hay feriados en la base de datos que no existan en las apis
+    const missingHolidays = holidays.filter(this.diff(holidaysApi));
+    //si existen los desactivo si su origen es distinto a Manual
+    if (missingHolidays.length > 0) {
+      for (const holiday of missingHolidays) {
+        if (holiday.origin !== 'Manual') {
+          holiday.active = false;
+          holiday.updatedAt = new Date();
+          await this.update(holiday);
+        }
+      }
+    }
+
+  }
+
+  //Metodo que retorna la diferencia entre dos array de objetos 
+  diff(otherArray: Holidays[]) {
+    return function (current: Holidays) {
+      return otherArray.filter((other: Holidays) => {
+        return other.name === current.name && other.country === current.country
+          && other.date.toString() === current.date.toString()
+      }).length === 0;
+    }
+  }
+
 }
+

--- a/src/services/api-chile-tranformer.service.ts
+++ b/src/services/api-chile-tranformer.service.ts
@@ -1,19 +1,21 @@
-import {injectable, /* inject, */ BindingScope} from '@loopback/core';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { injectable, /* inject, */ BindingScope } from '@loopback/core';
 import { Holidays } from '../models/holidays.model';
 
-@injectable({scope: BindingScope.TRANSIENT})
+@injectable({ scope: BindingScope.TRANSIENT })
 export class ApiChileTranformerService {
-  private country: string = 'cl';
-  private origin: string = 'ApiChile';
+  private country = 'cl';
+  private origin = 'APIChile';
 
-  constructor(/* Add @inject to inject parameters */) {}
+  constructor(/* Add @inject to inject parameters */) { }
 
   /*
    * Add service methods here
    */
-  transformer(data: any) {
+  async transformer(data: Array<any>): Promise<Holidays[]> {
+    const dataTranformer: Holidays[] = [];
+
     if (data) {
-      const dataTranformer = [];
 
       for (const item of data) {
         const model = new Holidays();
@@ -23,17 +25,21 @@ export class ApiChileTranformerService {
         }
 
         if (Object.prototype.hasOwnProperty.call(item, 'fecha')) {
-          model.date = item['fecha'];
+          model.date = new Date(item['fecha']);
         }
 
         model.country = this.country;
         model.origin = this.origin;
         model.active = true;
+        model.createdAt = new Date();
+        model.type = item['tipo'];
+
 
         dataTranformer.push(model);
       }
 
-      return dataTranformer;
     }
+    return dataTranformer;
+
   }
 }

--- a/src/services/google-api-transformer.service.ts
+++ b/src/services/google-api-transformer.service.ts
@@ -1,40 +1,42 @@
-import {injectable, /* inject, */ BindingScope} from '@loopback/core';
-import { Holidays } from '../models/holidays.model';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { injectable, BindingScope } from '@loopback/core';
+import { Holidays } from '../models';
 
-@injectable({scope: BindingScope.TRANSIENT})
+@injectable({ scope: BindingScope.TRANSIENT })
 export class GoogleApiTransformerService {
-  private origin: string = 'ApiGoogle';
+  private origin = 'Google';
 
-  constructor(/* Add @inject to inject parameters */) {}
+  constructor() { }
 
   /*
    * Add service methods here
    */
-  transformer(data: any, country: string) {
+  async transformer(data: any, country: string): Promise<Array<Holidays>> {
+    const dataTranformer = [];
     if (data) {
-      const dataTranformer = [];
 
       if (Object.prototype.hasOwnProperty.call(data, 'items')) {
         for (const item of data.items) {
           const model = new Holidays();
-  
+
           if (Object.prototype.hasOwnProperty.call(item, 'summary')) {
             model.name = item['summary'];
           }
-  
+
           if (Object.prototype.hasOwnProperty.call(item, 'start')) {
-            model.date = item['start']['date'];
+            model.date = new Date(item['start']['date']);
           }
-  
           model.country = country;
           model.origin = this.origin;
           model.active = true;
-  
+          model.createdAt = new Date();
+          model.type = 'Festivo';
           dataTranformer.push(model);
         }
-  
-        return dataTranformer;
+
       }
     }
+    return dataTranformer;
+
   }
 }

--- a/src/services/google-cal.service.ts
+++ b/src/services/google-cal.service.ts
@@ -12,7 +12,7 @@ export class GoogleCalProvider {
 
   async holidayEvents(year: number, country: string) {
     const calendar = google.calendar('v3');
-    const apiKey = process.env.API_KEY_GOOGLE ?? ''
+    const apiKey = process.env.GOOGLE_API_KEY ?? ''
     const auth = google.auth.fromAPIKey(apiKey);
     google.options({ auth });
     const timeMax = `${year}-12-31T23:59:59Z`;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,3 +1,4 @@
 export * from './apichile.service';
 export * from './google-cal.service';
 export * from './api-chile-tranformer.service';
+export * from './google-api-transformer.service';


### PR DESCRIPTION
Ticket TTB-8313
Crear una tarea que se ejecute cada 15 días para extraer los datos desde la fecha + 1año. 

Datos a considerar:

- Homologar códigos de países según calendario google
- Llenar datos de este año por cada país
- Verificar que el feriado no haya sido modificado manualmente (origin: manual)
- Si ya existe, no actualizar
- Si el feriado ya no existe en el origen, marcar como inactivo
- Actualizar sólo fechas hacia adelante, período a determinar
- La primera carga debe ser año completo

QA

Descargar rama.

- colocar datos en el .env de la base de datos Mongo y la api key de google.
- borrar de la DB los datos existentes en la colección Holidays.
- cambiar configuración del cron en _`src\components\cron.component.ts`_ para que ejecute el proceso de extracción de datos, verificar que se hayan creado los feriados.

Casos de Uso:
cambiar un feriado manualmente desde el endpoint `PATCH​ /admin​/holidays​/{id} `, al ejecutar la actualización el feriado debe seguir activo y verificar que no se haya creado un nuevo feriado.

Cambiar nombre de un feriado en la DB para simular que fue cambiado en la Api (Google o ApiChile), al ejecutar la actualización debe estar desactivado y debe haber creado un nuevo feriado activo reemplazando el anterior.

Eliminar un feriado en la BD para simular que hay un feriado nuevo en la Api (Google o ApiChile), al ejecutar la actualización debe haber creado el feriado que se eliminó anteriormente.

Crear feriado en la BD que no exista en la Api  (Google o ApiChile) para simular un feriado que fue eliminado en la Api, al ejecutar la actualización debe estar desactivado el feriado creado.




