### PR TITLE
TTB-8767 - Refactorizar método complejo en LemonHoliday

### DIFF
--- a/src/__tests__/acceptance/holidays.repository.acceptance.ts
+++ b/src/__tests__/acceptance/holidays.repository.acceptance.ts
@@ -35,15 +35,8 @@ describe('Acceptance Test HolidaysRepository', () => {
         expect(result).to.equal(null);
     });
 
-    it('invokes function createOrUpdate whitout holidays', async () => {
+    it('invokes function createOrUpdate when holidays is empty', async () => {
         await givenCountryInstance();
-        let result = await holidaysRepository.createOrUpdate()
-        expect(result).to.equal(null);
-    });
-
-    it('invokes function createOrUpdate when country is empty', async () => {
-        await givenCountryInstance();
-        await givenHolidayInstance();
         let result = await holidaysRepository.createOrUpdate()
         expect(result).to.equal(null);
     });

--- a/src/__tests__/acceptance/holidays.repository.acceptance.ts
+++ b/src/__tests__/acceptance/holidays.repository.acceptance.ts
@@ -16,45 +16,62 @@ describe('Acceptance Test HolidaysRepository', () => {
     });
 
     before(async () => {
-        await givenCountryInstance();
-        await givenHolidayInstance();
+        await givenHolidayRepository();
+        await givenCountryRepository();
+    });
+
+    beforeEach(async () => {
+        await givenEmptyDatabase();
+
     });
 
     after(async () => {
-        await givenEmptyDatabase();
         await app.stop();
     });
 
     it('invokes function createOrUpdate', async () => {
-        await givenHolidayRepository();
+        await givenCountryInstance();
+        await givenHolidayInstance();
+        let result = await holidaysRepository.createOrUpdate()
+        expect(result).to.equal(null);
+    });
+
+    it('invokes function createOrUpdate whitout holidays', async () => {
+        await givenCountryInstance();
         let result = await holidaysRepository.createOrUpdate()
         expect(result).to.equal(null);
     });
 
     it('invokes function createOrUpdate when country is empty', async () => {
-        await givenHolidayRepository();
+        await givenCountryInstance();
+        await givenHolidayInstance();
         let result = await holidaysRepository.createOrUpdate()
         expect(result).to.equal(null);
     });
 
     it('invokes function findByCountry', async () => {
-        await givenHolidayRepository();
+        await givenCountryInstance();
+        await givenHolidayInstance();
         let result = await holidaysRepository.findByCountry("pe", 2021)
         expect(result).to.be.eql([]);
     });
 
     it('invokes function findByCountry whitout year', async () => {
-        await givenHolidayRepository();
+        await givenCountryInstance();
+        await givenHolidayInstance();
         let result = await holidaysRepository.findByCountry("pe")
         expect(result).to.be.eql([]);
     });
 
-    async function givenCountryInstance(countries?: Partial<Countries>) {
+    async function givenCountryRepository() {
         countriesRepository = await app.getRepository(CountriesRepository);
+    }
+
+    async function givenCountryInstance(countries?: Partial<Countries>) {
         return countriesRepository.create(givenCountryData(countries));
     }
 
-    async function givenHolidayRepository(){
+    async function givenHolidayRepository() {
         holidaysRepository = await app.getRepository(HolidaysRepository);
     }
 

--- a/src/__tests__/acceptance/holidays.repository.acceptance.ts
+++ b/src/__tests__/acceptance/holidays.repository.acceptance.ts
@@ -20,9 +20,8 @@ describe('Acceptance Test HolidaysRepository', () => {
         await givenCountryRepository();
     });
 
-    beforeEach(async () => {
+    afterEach(async () => {
         await givenEmptyDatabase();
-
     });
 
     after(async () => {

--- a/src/__tests__/acceptance/holidays.repository.acceptance.ts
+++ b/src/__tests__/acceptance/holidays.repository.acceptance.ts
@@ -1,0 +1,65 @@
+import { Client, expect } from '@loopback/testlab';
+import { LemonholidaysApplication } from '../..';
+import { setupApplication } from './test-helper';
+import { HolidaysRepository } from '../../repositories/holidays.repository';
+import { CountriesRepository } from '../../repositories/countries.repository';
+import { Countries, Holidays } from '../../models';
+import { givenCountryData, givenHolidayData } from '../helpers/database.helpers';
+
+describe('Acceptance Test HolidaysRepository', () => {
+    let app: LemonholidaysApplication;
+    let holidaysRepository: HolidaysRepository;
+    let countriesRepository: CountriesRepository;
+
+    before('setupApplication', async () => {
+        ({ app } = await setupApplication());
+    });
+
+    before(async () => {
+        await givenCountryInstance();
+        await givenHolidayInstance();
+    });
+
+    after(async () => {
+        await givenEmptyDatabase();
+        await app.stop();
+    });
+
+    it('invokes function createOrUpdate', async () => {
+        await givenHolidaysRepository();
+        let result = await holidaysRepository.createOrUpdate()
+        expect(result).to.equal(null);
+    });
+
+    it('invokes function findByCountry', async () => {
+        await givenHolidaysRepository();
+        let result = await holidaysRepository.findByCountry("pe", 2021)
+        expect(result).to.be.eql([]);
+    });
+
+    it('invokes function findByCountry whitout year', async () => {
+        await givenHolidaysRepository();
+        let result = await holidaysRepository.findByCountry("pe")
+        expect(result).to.be.eql([]);
+    });
+
+    async function givenHolidaysRepository() {
+        holidaysRepository = await app.getRepository(HolidaysRepository);
+    }
+
+    async function givenCountryInstance(countries?: Partial<Countries>) {
+        countriesRepository = await app.getRepository(CountriesRepository);
+        return countriesRepository.create(givenCountryData(countries));
+    }
+
+    async function givenHolidayInstance(holidays?: Partial<Holidays>) {
+        holidaysRepository = await app.getRepository(HolidaysRepository);
+        return holidaysRepository.create(givenHolidayData(holidays));
+    }
+
+    async function givenEmptyDatabase() {
+        await holidaysRepository.deleteAll();
+        await countriesRepository.deleteAll();
+    }
+
+});

--- a/src/__tests__/acceptance/holidays.repository.acceptance.ts
+++ b/src/__tests__/acceptance/holidays.repository.acceptance.ts
@@ -26,34 +26,39 @@ describe('Acceptance Test HolidaysRepository', () => {
     });
 
     it('invokes function createOrUpdate', async () => {
-        await givenHolidaysRepository();
+        await givenHolidayRepository();
+        let result = await holidaysRepository.createOrUpdate()
+        expect(result).to.equal(null);
+    });
+
+    it('invokes function createOrUpdate when country is empty', async () => {
+        await givenHolidayRepository();
         let result = await holidaysRepository.createOrUpdate()
         expect(result).to.equal(null);
     });
 
     it('invokes function findByCountry', async () => {
-        await givenHolidaysRepository();
+        await givenHolidayRepository();
         let result = await holidaysRepository.findByCountry("pe", 2021)
         expect(result).to.be.eql([]);
     });
 
     it('invokes function findByCountry whitout year', async () => {
-        await givenHolidaysRepository();
+        await givenHolidayRepository();
         let result = await holidaysRepository.findByCountry("pe")
         expect(result).to.be.eql([]);
     });
-
-    async function givenHolidaysRepository() {
-        holidaysRepository = await app.getRepository(HolidaysRepository);
-    }
 
     async function givenCountryInstance(countries?: Partial<Countries>) {
         countriesRepository = await app.getRepository(CountriesRepository);
         return countriesRepository.create(givenCountryData(countries));
     }
 
-    async function givenHolidayInstance(holidays?: Partial<Holidays>) {
+    async function givenHolidayRepository(){
         holidaysRepository = await app.getRepository(HolidaysRepository);
+    }
+
+    async function givenHolidayInstance(holidays?: Partial<Holidays>) {
         return holidaysRepository.create(givenHolidayData(holidays));
     }
 

--- a/src/__tests__/helpers/database.helpers.ts
+++ b/src/__tests__/helpers/database.helpers.ts
@@ -1,21 +1,50 @@
-import { Applications, User, UserCredentials } from '../../models';
+import { Applications, User, UserCredentials, Countries, Holidays } from '../../models';
 
 export function givenApplicationData(application?: Partial<Applications>) {
   const data = Object.assign({
-      name: 'applications test',
-      key: '<key-ds>',
-    },
+    name: 'applications test',
+    key: '<key-ds>',
+  },
     application,
   );
 
   return new Applications(data);
 }
 
+export function givenCountryData(country?: Partial<Countries>) {
+  const data = Object.assign({
+    name: 'Chile',
+    code: "cl",
+    origin: "APIChile",
+    googleCode: "cl"
+  },
+    country,
+  );
+
+  return new Countries(data);
+}
+
+export function givenHolidayData(holiday?: Partial<Holidays>) {
+  const data = Object.assign({
+    name: "Feriado Test",
+    date: new Date(),
+    type: "Civil",
+    origin: "APIChile",
+    country: "cl",
+    active: true,
+    createdAt: new Date()
+  },
+    holiday,
+  );
+
+  return new Holidays(data);
+}
+
 export function givenUserData(user?: Partial<User>) {
   const data = Object.assign({
-      id: 'mogo-id-obj',
-      email: 'admin@email.com',
-    },
+    id: 'mogo-id-obj',
+    email: 'admin@email.com',
+  },
     user,
   );
 
@@ -24,10 +53,10 @@ export function givenUserData(user?: Partial<User>) {
 
 export function givenUserCredentialsData(user?: Partial<UserCredentials>) {
   const data = Object.assign({
-      id: 'mogo-id-obj-2',
-      password: 'secure-password',
-      userId: 'mogo-id-obj',
-    },
+    id: 'mogo-id-obj-2',
+    password: 'secure-password',
+    userId: 'mogo-id-obj',
+  },
     user,
   );
 


### PR DESCRIPTION
Ticket TTB-8767

Se necesita refactorizar método updateAllByCountry.

QA

Descargar rama.

- colocar datos en el .env de la base de datos Mongo y la api key de google.
- borrar de la DB los datos existentes en la colección Holidays.
- cambiar configuración del cron en _`.env`_ para que ejecute el proceso de extracción de datos, verificar que se hayan creado los feriados.

Casos de Prueba:

Cambiar un feriado manualmente desde el endpoint `PATCH​ /admin​/holidays​/{id} `, al ejecutar la actualización el feriado debe seguir activo y verificar que no se haya creado un nuevo feriado.

Cambiar nombre de un feriado en la DB con fecha mayor a la actual para simular que fue cambiado en la Api (Google o ApiChile), al ejecutar la actualización debe estar desactivado y debe haber creado un nuevo feriado activo reemplazando el anterior.

Eliminar un feriado en la BD con fecha mayor a la actual para simular que hay un feriado nuevo en la Api (Google o ApiChile), al ejecutar la actualización debe haber creado el feriado que se eliminó anteriormente.

Crear feriado en la BD con fecha mayor a la actual que no exista en la Api  (Google o ApiChile) para simular un feriado que fue eliminado en la Api, al ejecutar la actualización debe estar desactivado el feriado creado.




