### PR TITLE
TTB-9239 - Retornar la misma fecha para feriados que tienen la misma fecha

### DIFF
--- a/src/__tests__/acceptance/holidays.repository.acceptance.ts
+++ b/src/__tests__/acceptance/holidays.repository.acceptance.ts
@@ -55,6 +55,32 @@ describe('Acceptance Test HolidaysRepository', () => {
     expect(result).to.be.eql([]);
   });
 
+  it('invokes function findByCountry with data result', async () => {
+    await givenCountryInstance();
+    const holiday = await givenHolidayInstance();
+    const result = await holidaysRepository.findByCountry("cl", 2021)
+
+    expect(result).to.be.eql([holiday]);
+  });
+
+  it('invokes function findByCountry with equal dates holidays ', async () => {
+    await givenCountryInstance();
+
+    const holidays = [];
+
+    for (let index = 0; index < 3; index++) {
+      const currentHoliday = await givenHolidayInstance();
+      holidays.push(currentHoliday);
+    }
+
+    const rootHoliday = holidays[0];
+    holidays.splice(0, 1);
+    rootHoliday.data = holidays;
+    const result = await holidaysRepository.findByCountry("cl", 2021)
+
+    expect(result).to.be.eql([rootHoliday]);
+  });
+
   async function givenCountryRepository() {
     countriesRepository = await app.getRepository(CountriesRepository);
   }

--- a/src/__tests__/helpers/database.helpers.ts
+++ b/src/__tests__/helpers/database.helpers.ts
@@ -27,7 +27,7 @@ export function givenCountryData(country?: Partial<Countries>) {
 export function givenHolidayData(holiday?: Partial<Holidays>) {
   const data = Object.assign({
     name: "Feriado Test",
-    date: new Date(),
+    date: new Date('2021-12-12'),
     type: "Civil",
     origin: "APIChile",
     country: "cl",

--- a/src/controllers/holidays.controller.ts
+++ b/src/controllers/holidays.controller.ts
@@ -51,7 +51,7 @@ export class HolidaysController {
     @param.header.string('appKey') appKey: string,
     @param.path.string('country') country: string,
     @param.query.number('year') year?: number,
-  ): Promise<Holidays[]> {
+  ) {
     const authorized = await this.appKeyProvider.authorize(appKey);
     if (!authorized) {
       throw new Error("Unauthorized");

--- a/src/controllers/holidays.controller.ts
+++ b/src/controllers/holidays.controller.ts
@@ -51,7 +51,7 @@ export class HolidaysController {
     @param.header.string('appKey') appKey: string,
     @param.path.string('country') country: string,
     @param.query.number('year') year?: number,
-  ) {
+  ): Promise<Holidays[]> {
     const authorized = await this.appKeyProvider.authorize(appKey);
     if (!authorized) {
       throw new Error("Unauthorized");

--- a/src/models/holidays.model.ts
+++ b/src/models/holidays.model.ts
@@ -55,6 +55,7 @@ export class Holidays extends Entity {
   updatedAt?: Date;
 
   @property({
+    default: [],
     itemType: Holidays
   })
   data?: Array<Holidays>;

--- a/src/models/holidays.model.ts
+++ b/src/models/holidays.model.ts
@@ -54,6 +54,11 @@ export class Holidays extends Entity {
   })
   updatedAt?: Date;
 
+  @property({
+    itemType: Holidays
+  })
+  data?: Array<Holidays>;
+
   constructor(data?: Partial<Holidays>) {
     super(data);
   }

--- a/src/repositories/holidays.repository.ts
+++ b/src/repositories/holidays.repository.ts
@@ -45,6 +45,19 @@ export class HolidaysRepository extends DefaultCrudRepository<
           }
         ]
       }
+    }).then(data => {
+      data.reduce((result, currentValue) => {
+        // If an array already present for key, push it to the array. Else create an array and push the object
+        const index = data.findIndex(value => {
+          return value.date === currentValue.date;
+        })
+
+        console.log(index);
+        // Return the current iteration `result` value, this will be taken as next iteration `result` value and accumulate
+        return result;
+      }, [])
+
+      return data;
     })
 
   }

--- a/src/repositories/holidays.repository.ts
+++ b/src/repositories/holidays.repository.ts
@@ -46,18 +46,23 @@ export class HolidaysRepository extends DefaultCrudRepository<
         ]
       }
     }).then(data => {
-      data.reduce((result, currentValue) => {
-        // If an array already present for key, push it to the array. Else create an array and push the object
-        const index = data.findIndex(value => {
-          return value.date === currentValue.date;
+      const parseData: Array<Holidays> = [];
+
+      data.forEach((currentValue, currentIndex) => {
+        const resultIndex = parseData.findIndex((value, index) => {
+          return  value.date.getTime() === currentValue.date.getTime() && index !== currentIndex
         })
 
-        console.log(index);
-        // Return the current iteration `result` value, this will be taken as next iteration `result` value and accumulate
-        return result;
-      }, [])
+        if (resultIndex === -1) {
+          parseData.push(currentValue);
+        } else {
+          data.splice(1, resultIndex);
+          parseData[resultIndex].data = [];
+          parseData[resultIndex].data?.push(currentValue);
+        }
+      });
 
-      return data;
+      return parseData;
     })
 
   }

--- a/src/repositories/holidays.repository.ts
+++ b/src/repositories/holidays.repository.ts
@@ -48,16 +48,15 @@ export class HolidaysRepository extends DefaultCrudRepository<
     }).then(data => {
       const parseData: Array<Holidays> = [];
 
-      data.forEach((currentValue, currentIndex) => {
-        const resultIndex = parseData.findIndex((value, index) => {
-          return  value.date.getTime() === currentValue.date.getTime() && index !== currentIndex
+      data.forEach(currentValue => {
+        const resultIndex = parseData.findIndex(value => {
+          return  value.date.getTime() === currentValue.date.getTime()
         })
 
         if (resultIndex === -1) {
           parseData.push(currentValue);
         } else {
-          data.splice(1, resultIndex);
-          parseData[resultIndex].data = [];
+          parseData[resultIndex].data = parseData[resultIndex].data ?? [];
           parseData[resultIndex].data?.push(currentValue);
         }
       });


### PR DESCRIPTION
### Ticket [TTB-9239](https://lemontech.atlassian.net/browse/TTB-9239)

Efemérides 

### Análisis

Cuando se consulta al endpoint:  `/holidays/{country}` devuelve los feriados del país y año que recibe como parámetro pero si existe varias días festivos en una sola fecha estos son devueltos como registros por separado, se requiere que en una fecha se devuelvan todos los feriados que existen 

### Solución

Se agrego una nueva propiedad al modelo Holiday (propiedad: data) que será un array donde se listaran todos los feriados en esa misma fecha, sin un orden en especifico, el primer feriado en una fecha en particular será tomado como padre y los demás feriados que coincidan con la fecha serán puestos dentro de la propiedad data.

### QA

- Descargar la rama y probar el endpoint:  `/holidays/{country}`.

![image](https://user-images.githubusercontent.com/22380249/147701671-8cca0a96-412c-4cbe-a0c7-e068be4c2b67.png)

