### PR TITLE
TTB-9300 - Fix sentry LEMONHOLIDAYS-BACKEND-P

### DIFF
--- a/src/middleware/log.middleware.ts
+++ b/src/middleware/log.middleware.ts
@@ -11,10 +11,9 @@ export const logMiddleware: Middleware = async (middlewareCtx: MiddlewareContext
   try {
     return await next();
   } catch (error) {
-    if (error.message !== 'Unauthorized') {
+    if (error.name !== 'UnauthorizedError' && error.name !== 'NotFoundError') {
       Sentry.captureException(error);
-      throw error;
     }
-    middlewareCtx.response.status(401).json({code: 401, status: 'Unauthorized!'});
+    throw error;
   }
 }


### PR DESCRIPTION
### Ticket [TTB-9300](https://lemontech.atlassian.net/browse/TTB-9300)

Se produce un error al intentar acceder a una ruta no existente, esto no debería llegar a sentry

```
NotFoundError: Endpoint "GET /holidays/" not found.
  File "/home/node/app/dist/middleware/log.middleware.js", line 13, in async logMiddleware
    const result = await next();
```

### Solución
Validar lo que sentry registra. Escapar los errores 404