### PR TITLE
TTB-925 - Application autorization is not working

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,11 @@
+### Ticket [TTB-0000](https://lemontech.atlassian.net/browse/TTB-0000)
+
+[descripción]
+
+### Implementación
+
+[implementación]
+
+### QA
+
+[QA]

--- a/src/__tests__/unit/services/app-key.service.unit.ts
+++ b/src/__tests__/unit/services/app-key.service.unit.ts
@@ -1,0 +1,47 @@
+import {
+  expect,
+  StubbedInstanceWithSinonAccessor,
+  createStubInstance
+} from '@loopback/testlab';
+import { Applications } from '../../../models';
+import { givenApplicationData } from '../../helpers/database.helpers';
+import { ApplicationsRepository } from '../../../repositories/applications.repository';
+import { AppKeyProvider } from '../../../services/app-key.service';
+
+describe('Unit Test AppKeyProvider', () => {
+  let appKeyService: AppKeyProvider;
+  let applicationInstance: Applications;
+  let applicationInstances: Applications[];
+  let repository: StubbedInstanceWithSinonAccessor<ApplicationsRepository>;
+
+  beforeEach(resetTest);
+
+  it('authorize with valid app key', async () => {
+    const createStubMethod = repository.stubs.find;
+    createStubMethod.resolves(applicationInstances);
+    const result = await appKeyService.authorize(applicationInstance.key);
+    expect(result).to.be.true();
+  });
+
+  it('authorize with invalid app key', async () => {
+    const createStubMethod = repository.stubs.find;
+    createStubMethod.resolves([]);
+    const result = await appKeyService.authorize("invalid-key");
+    expect(result).to.be.false();
+  });
+
+  it('authorize with empty app key', async () => {
+    const createStubMethod = repository.stubs.find;
+    createStubMethod.resolves(applicationInstances);
+    const result = await appKeyService.authorize("");
+    expect(result).to.be.false();
+  });
+
+  function resetTest() {
+    applicationInstances = [];
+    repository = createStubInstance(ApplicationsRepository);
+    appKeyService = new AppKeyProvider(repository);
+    applicationInstances.push(givenApplicationData());
+    applicationInstance = givenApplicationData({key: "key-test"});
+  }
+});

--- a/src/__tests__/unit/services/google-api-transformer.service.unit.ts
+++ b/src/__tests__/unit/services/google-api-transformer.service.unit.ts
@@ -20,8 +20,7 @@ describe('Unit Test GoogleApiTransformerService', () => {
 
   it('invokes function transformer', async () => {
 
-    let googleApiTransformerService = new GoogleApiTransformerService();
-    let dataTransformed: Array<Holidays>;
+    const googleApiTransformerService = new GoogleApiTransformerService();
     const data: Object = {
       "items": [
         {
@@ -39,9 +38,9 @@ describe('Unit Test GoogleApiTransformerService', () => {
       ]
     };
 
-    const country: string = "pe";
-    let controller = new GoogleController(googleApiTransformerService);
-    dataTransformed = await controller.callgoogleApiTransformer(data, country);
+    const country = "pe";
+    const controller = new GoogleController(googleApiTransformerService);
+    const dataTransformed = await controller.callgoogleApiTransformer(data, country);
     expect(dataTransformed.length).to.eql(2);
     expect(dataTransformed[0]['country']).to.eql(country);
     expect(dataTransformed[0]['date']).to.eql(new Date("2021-03-28"));

--- a/src/services/app-key.service.ts
+++ b/src/services/app-key.service.ts
@@ -9,10 +9,16 @@ export class AppKeyProvider {
     ) { }
 
   async authorize(key: string) {
+    if (!key) {
+      return false;
+    }
+
     const result = await this.applicationsRepository.find({where: {'key': key}});
+
     if (result.length > 0) {
       return true;
     }
+
     return false;
   }
 }


### PR DESCRIPTION
### Ticket [TTB-9256](https://lemontech.atlassian.net/browse/TTB-9256)

Bug en autorización de aplicaciones, cuando se envía el header de autorización (`appKey`) vacío debería devolver un 401

### Implementación

Se valida que el header de autorización no este vacío

### QA

- Descargar la rama y probar el endpoint  `​/holidays​/{country}`
