### PR TITLE
TTB-10160 -  Deshabilitar cuando se elimina

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "lemonholidays",
       "version": "0.0.1",
       "dependencies": {
         "@loopback/authentication": "^7.2.0",

--- a/src/controllers/admin-holiday.controller.ts
+++ b/src/controllers/admin-holiday.controller.ts
@@ -122,7 +122,7 @@ export class AdminHolidayController {
     description: 'Admin Holiday DELETE success',
   })
   async deleteById(@param.path.string('id') id: string): Promise<void> {
-    await this.holidaysRepository.deleteById(id);
+    await this.holidaysRepository.disableById(id);
   }
 
   @authenticate('jwt')

--- a/src/controllers/admin-holiday.controller.ts
+++ b/src/controllers/admin-holiday.controller.ts
@@ -122,7 +122,7 @@ export class AdminHolidayController {
     description: 'Admin Holiday DELETE success',
   })
   async deleteById(@param.path.string('id') id: string): Promise<void> {
-    await this.holidaysRepository.disableById(id);
+    return this.holidaysRepository.disableById(id);
   }
 
   @authenticate('jwt')

--- a/src/repositories/holidays.repository.ts
+++ b/src/repositories/holidays.repository.ts
@@ -180,7 +180,7 @@ export class HolidaysRepository extends DefaultCrudRepository<
   async disableById(id: string) {
     const holiday = await this.findById(id);
     holiday.active = false;
-    await this.update(holiday);
+    return this.update(holiday);
   }
 
 }

--- a/src/repositories/holidays.repository.ts
+++ b/src/repositories/holidays.repository.ts
@@ -42,6 +42,9 @@ export class HolidaysRepository extends DefaultCrudRepository<
           },
           {
             date: { between: [first, last] }
+          },
+          {
+            active: true
           }
         ]
       }
@@ -172,6 +175,12 @@ export class HolidaysRepository extends DefaultCrudRepository<
       await this.updateById(holidayFind.id, holidayFind);
       await this.create(holiday);
     }
+  }
+
+  async disableById(id: string) {
+    const holiday = await this.findById(id);
+    holiday.active = false;
+    await this.update(holiday);
   }
 
 }


### PR DESCRIPTION
### Ticket [TTB-10160](https://lemontech.atlassian.net/browse/TTB-10160)
Se reporta que a pesar de eliminar ciertos feriados, estos vuelven a aparecer.
Esto se debe a que existe un proceso que revisa periódicamente si existen nuevos feriados y actualiza o crea estos feriados, entonces al estar eliminados, se vuelven a crear.

### Implementación
Para solucionar este problema, se opta por desactivar el feriado en lugar de eliminarlo y de esta forma, se filtra el listado de feriados del año de un país mostrando solo los feriados activos.
